### PR TITLE
Use correct env vars for obtaining github token

### DIFF
--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/iac/terraform-framework/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/iac/terraform-framework/scripts/global/pipeline/common/functions.sh
@@ -67,8 +67,7 @@ function launch_predict_semver {
 
 function launch_apply_semver {
     local branch="${BUILD_BRANCH:-main}"
-
-    install_asdf "${HOME}"
+    install_asdf "${HOME}" 
     set_vars_script_and_clone_service
     git_checkout "${MERGE_COMMIT_ID}" "${CODEBUILD_SRC_DIR}/${GIT_REPO}"
     if git merge-base --is-ancestor "${MERGE_COMMIT_ID}" "origin/${branch}"; then


### PR DESCRIPTION
Two new environment variables are added AWS_PROFILE_LOGIN_ENV and AWS_PROFILE_LOGIN_ROLE. These are used to always login to aws `root` account and create aws profile that is then passed by `launch-cli` command.