### PR TITLE
changing var as the other is reserved

### DIFF
--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/common/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/common/scripts/global/pipeline/common/functions.sh
@@ -43,7 +43,7 @@ function trigger_pipeline {
         "${TO_BRANCH}" \
         "${PROPERTIES_REPO_SUFFIX}" \
         "${GIT_SERVER_URL}" \
-        "${IMAGE_TAG}" \
+        "${IMAGE_TAG_PREFIX}" \
         "${SERVICE_COMMIT}" \
         "${CODEBUILD_SRC_DIR}" \
         "${GIT_ORG}"


### PR DESCRIPTION
- changing var as `IMAGE_TAG` is reserved in codebuild docker. 

will be tagged `1.3.3`