### PR TITLE
fixing bug for pushing image to ecr

### DIFF
--- a/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/service-platforms/ecs-platform/scripts/global/pipeline/common/functions.sh
+++ b/linkfiles/pipeline_providers/aws/aws_pipeline-to-aws_cloud/codebuild/service-platforms/ecs-platform/scripts/global/pipeline/common/functions.sh
@@ -10,7 +10,7 @@ fi
 
 function certify_image {
     set_vars_from_script "${CODEBUILD_SRC_DIR}/set_vars.sh"
-    add_ecr_image_tag "${NEW_IMAGE_TAG}" "${MERGE_COMMIT_ID}" "${GIT_REPO}"
+    add_ecr_image_tag "${NEW_IMAGE_TAG}" "${MERGE_COMMIT_ID}" "${CONTAINER_IMAGE_NAME}"
 }
 
 function set_make_vars_and_artifact_token {


### PR DESCRIPTION
- bug where it should be passing the `CONTAINER_IMAGE_NAME` var not `GIT_REPO`